### PR TITLE
Added new option to ignore vehicles with no players in them

### DIFF
--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         author = "Freestyle_Build";
         units[] = {};
         weapons[] = {};
-        requiredVersion = 1.98;
+        requiredVersion = 2.00;
         requiredAddons[] = {"cba_main"};
     };
 };

--- a/addons/main/functions/fnc_handleDamage.sqf
+++ b/addons/main/functions/fnc_handleDamage.sqf
@@ -23,6 +23,17 @@ private _stateThreshold = GVARMAIN(stateThreshold);
 private _damageThreshold = GVARMAIN(damageTreshold) / 100;
 private _state = _aircraft getVariable [QGVARMAIN(state), 0];
 private _result = 0;
+private _ignoreNonPlayerVehicles = GVARMAIN(ignoreNonPlayerVehicles);
+private _playerInVehicle = false;
+
+if (_ignoreNonPlayerVehicles) then
+{
+	private _playerInVehicle = {
+		if (isPlayer _x) exitWith { true }; 
+		false;
+	} forEach (crew _aircraft);
+};
+if (_ignoreNonPlayerVehicles and !_playerInVehicle) exitWith { _damage };
 
 if ((_stateThreshold > _state) and (alive _aircraft)) then 
 {

--- a/addons/main/initSettings.sqf
+++ b/addons/main/initSettings.sqf
@@ -19,8 +19,17 @@
 [
     QGVARMAIN(captiveSystem),
     "CHECKBOX",
-    ["Captive System and AI-Anti-Bailing", "Prevent enemies from shooting crashing aircraft, preevent AI passangers from ejecting mid-air"],
+    ["Captive System and AI-Anti-Bailing", "Prevent enemies from shooting crashing aircraft, prevent AI passangers from ejecting mid-air"],
     ["Freestyle's Crash Landing", "Captive and Anti-Bailing"],
+    [true],
+    1
+] call CBA_fnc_addSetting;
+
+[
+    QGVARMAIN(ignoreNonPlayerVehicles),
+    "CHECKBOX",
+    ["Ignore vehicles with no players in them", "If enabled, excludes any AI-only vehicles from the script."],
+    ["Freestyle's Crash Landing", "Ignore NPC vehicles"],
     [true],
     1
 ] call CBA_fnc_addSetting;
@@ -55,7 +64,7 @@
 [
     QGVARMAIN(debug),
     "CHECKBOX",
-    ["Enable denug output", "Enables certain debug outputs of the scripts, only for development purposes."],
+    ["Enable debug output", "Enables certain debug outputs of the scripts, only for development purposes."],
     ["Freestyle's Crash Landing", "Development Settings"],
     [false],
     1

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -7,7 +7,7 @@
 #define BETA ##VERSION##-##beta
 #define RC ##VERSION##-##RC
 
-#define REQUIRED_VERSION 1.98
+#define REQUIRED_VERSION 2.00
 #define COMPONENT_NAME QUOTE(FSCL - COMPONENT)
 
 #include "\x\cba\addons\main\script_macros_common.hpp"


### PR DESCRIPTION
This adds a new CBA option to ignore vehicles with no players in them (default true).

As mentioned in my comment on the Steam Workshop page, what can happen currently:
- even with 99% damage threshold, AI can land aircraft, bail out, and leave you with a perfectly repairable and capturable airframe with can be seen as unbalanced for PVE scenarios like Escape and Liberation
- AI can still sometimes target downed AI aircraft, wasting ammo, though this could be a result of AI mods interfering with the captive script

I think having this as an option makes sense for people that want the chance of recovering downed AI-driven aircraft.
If you think this should be set to false by default, I'm fine with that as well.